### PR TITLE
Implement media persistence and cleanup command

### DIFF
--- a/backend/migrations/Version20250605000000.php
+++ b/backend/migrations/Version20250605000000.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20250605000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Make media.article_id nullable';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE media CHANGE article_id article_id INT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE media CHANGE article_id article_id INT NOT NULL');
+    }
+}

--- a/backend/src/Command/CleanOrphanMediaCommand.php
+++ b/backend/src/Command/CleanOrphanMediaCommand.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\Media;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:clean-orphan-media',
+    description: 'Remove files from the uploads directory that are not referenced in the media table.'
+)]
+final class CleanOrphanMediaCommand extends Command
+{
+    public function __construct(private EntityManagerInterface $em, private string $projectDir)
+    {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $uploadDir = $this->projectDir . '/public/uploads';
+        if (!is_dir($uploadDir)) {
+            $io->error(sprintf('Upload directory "%s" does not exist.', $uploadDir));
+            return Command::FAILURE;
+        }
+
+        $urls = $this->em->getRepository(Media::class)
+            ->createQueryBuilder('m')
+            ->select('m.url')
+            ->getQuery()
+            ->getSingleColumnResult();
+        $urls = array_map(fn($u) => ltrim($u, '/'), $urls);
+
+        $removed = 0;
+        $files = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($uploadDir, \FilesystemIterator::SKIP_DOTS));
+        foreach ($files as $file) {
+            if (!$file->isFile()) {
+                continue;
+            }
+            $relative = ltrim(str_replace($this->projectDir . '/public/', '', $file->getPathname()), '/');
+            if (!in_array($relative, $urls, true)) {
+                unlink($file->getPathname());
+                $removed++;
+            }
+        }
+
+        $io->success(sprintf('%d orphan file(s) removed.', $removed));
+
+        return Command::SUCCESS;
+    }
+}

--- a/backend/src/Entity/Media.php
+++ b/backend/src/Entity/Media.php
@@ -23,7 +23,7 @@ class Media
     private ?\DateTimeImmutable $uploaded_at = null;
 
     #[ORM\ManyToOne(inversedBy: 'media')]
-    #[ORM\JoinColumn(nullable: false)]
+    #[ORM\JoinColumn(nullable: true)]
     private ?Article $article = null;
 
     public function getId(): ?int

--- a/frontend/src/app/editor/articles/edit/[id]/page.tsx
+++ b/frontend/src/app/editor/articles/edit/[id]/page.tsx
@@ -374,6 +374,7 @@ export default function EditArticlePage() {
                                     value={step.content}
                                     onChange={(val) => handleStepChange(i, "content", val)}
                                     placeholder={stepPlaceholders[i] || "Commence à écrire ici..."}
+                                    articleId={parseInt(articleId as string)}
                                 />
                             </StepBlock>
                         ))}
@@ -410,6 +411,7 @@ export default function EditArticlePage() {
                                     value={conclusionDescription}
                                     onChange={(val) => setConclusionDescription(val)}
                                     placeholder="Résume les points clés et propose les prochaines étapes..."
+                                    articleId={parseInt(articleId as string)}
                                 />
                             </div>
                         </div>

--- a/frontend/src/components/admin/article/new/MediaUploader.tsx
+++ b/frontend/src/components/admin/article/new/MediaUploader.tsx
@@ -8,9 +8,10 @@ interface MediaUploaderProps {
     type?: 'image' | 'video' | 'document' | 'all';
     label?: string;
     icon?: ReactNode;
+    articleId?: number;
 }
 
-export const MediaUploader = ({ onSuccess, onError, type = 'all', label, icon }: MediaUploaderProps) => {
+export const MediaUploader = ({ onSuccess, onError, type = 'all', label, icon, articleId }: MediaUploaderProps) => {
     const [uploading, setUploading] = useState(false);
 
     const getAcceptTypes = () => {
@@ -33,8 +34,11 @@ export const MediaUploader = ({ onSuccess, onError, type = 'all', label, icon }:
         try {
             const formData = new FormData();
             formData.append('file', file);
+            if (articleId) {
+                formData.append('article_id', articleId.toString());
+            }
 
-            const response = await fetch('/api/upload', {  // URL modifiée
+            const response = await fetch('/api/media/upload', {
                 method: 'POST',
                 body: formData,
             });

--- a/frontend/src/components/admin/article/new/RichTextEditor.tsx
+++ b/frontend/src/components/admin/article/new/RichTextEditor.tsx
@@ -57,9 +57,10 @@ type Props = {
     value: any;
     onChange: (value: any) => void;
     placeholder?: string;
+    articleId?: number;
 };
 
-export function RichTextEditor({ value, onChange, placeholder }: Props) {
+export function RichTextEditor({ value, onChange, placeholder, articleId }: Props) {
     const [hasMounted, setHasMounted] = useState(false);
     const [open, setOpen] = useState(false);
     const active = "px-2 py-1 text-white bg-zinc-700 border border-zinc-600 rounded";
@@ -227,6 +228,7 @@ export function RichTextEditor({ value, onChange, placeholder }: Props) {
                                                 type="image"
                                                 label="Télécharger une image"
                                                 icon={<ImagesIcon size={20} />}
+                                                articleId={articleId}
                                                 onSuccess={(url, mimeType) => {
                                                     if (mimeType.startsWith('image/')) {
                                                         const alt = prompt("Texte alternatif (description de l'image) ?") || "Image ajoutée";
@@ -263,6 +265,7 @@ export function RichTextEditor({ value, onChange, placeholder }: Props) {
                                                 type="video"
                                                 label="Télécharger une vidéo"
                                                 icon={<Video size={20} />}
+                                                articleId={articleId}
                                                 onSuccess={(url, mimeType) => {
                                                     // Utiliser l'extension vidéo pour insérer la vidéo correctement
                                                     editor?.chain().focus().insertContent({
@@ -323,6 +326,7 @@ export function RichTextEditor({ value, onChange, placeholder }: Props) {
                                                 type="document"
                                                 label="Télécharger un document"
                                                 icon={<FileText size={20} />}
+                                                articleId={articleId}
                                                 onSuccess={(url, mimeType) => {
                                                     // Pour les documents (PDF, Word, etc.)
                                                     const fileExt = url.split('.').pop()?.toLowerCase();


### PR DESCRIPTION
## Summary
- save uploads to the `media` table with optional article linkage
- allow `Media` records without article
- add migration to make `media.article_id` nullable
- provide `app:clean-orphan-media` console command
- send `article_id` when uploading from the editor

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841dfb5ca94832f91f9123d8ee2b5fc