### PR TITLE
Fix CleanOrphanMediaCommand for Doctrine 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,5 +117,20 @@ Quickly insert visuals or layout elements without disrupting the writing flow.
 
 ![localhost_3100_account_settings](https://github.com/user-attachments/assets/dd8b73ca-8a84-4388-9cb7-9f6da6074d4f)
 
+---
+
+#### Cleaning orphan media files
+
+The backend provides a `app:clean-orphan-media` command to remove files from
+`public/uploads` that are no longer referenced in the database.
+
+```bash
+cd backend
+php bin/console app:clean-orphan-media
+```
+
+The command prints how many orphan files were removed. Only files missing from
+the `media` table are deleted.
+
 
 

--- a/backend/src/Command/CleanOrphanMediaCommand.php
+++ b/backend/src/Command/CleanOrphanMediaCommand.php
@@ -35,7 +35,8 @@ final class CleanOrphanMediaCommand extends Command
             ->createQueryBuilder('m')
             ->select('m.url')
             ->getQuery()
-            ->getSingleColumnResult();
+            ->getArrayResult();
+        $urls = array_column($urls, 'url');
         $urls = array_map(fn($u) => ltrim($u, '/'), $urls);
 
         $removed = 0;


### PR DESCRIPTION
## Summary
- adjust CleanOrphanMediaCommand for Doctrine ORM 3 compatibility
- document manual command check to remove orphan uploads

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ebc91364832f8547033e4ed710f6