### PR TITLE
Use Autowire attribute for project dir

### DIFF
--- a/backend/src/Command/CleanOrphanMediaCommand.php
+++ b/backend/src/Command/CleanOrphanMediaCommand.php
@@ -9,6 +9,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 #[AsCommand(
     name: 'app:clean-orphan-media',
@@ -16,7 +17,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 )]
 final class CleanOrphanMediaCommand extends Command
 {
-    public function __construct(private EntityManagerInterface $em, private string $projectDir)
+    public function __construct(private EntityManagerInterface $em, #[Autowire('%kernel.project_dir%')] private string $projectDir)
     {
         parent::__construct();
     }


### PR DESCRIPTION
## Summary
- import `Autowire` attribute
- inject project directory via `#[Autowire('%kernel.project_dir%')]`

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6841f492a320832fa307c70c25a61a1e